### PR TITLE
fix(automation):Adding option to turn off branch protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ No modules.
 | <a name="input_allow_squash_merge"></a> [allow\_squash\_merge](#input\_allow\_squash\_merge) | Whether to allow squash merges | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | The description of the repository | `string` | n/a | yes |
 | <a name="input_gitignore_template"></a> [gitignore\_template](#input\_gitignore\_template) | The gitignore template of the repository | `string` | `null` | no |
+| <a name="input_has_branch_protection"></a> [has\_branch\_protection](#input\_has\_branch\_protection) | Whether the repository has branch protection enabled | `bool` | `true` | no |
 | <a name="input_has_discussions"></a> [has\_discussions](#input\_has\_discussions) | Whether the repository has discussions enabled | `bool` | `false` | no |
 | <a name="input_has_issues"></a> [has\_issues](#input\_has\_issues) | Whether the repository has issues enabled | `bool` | `false` | no |
 | <a name="input_has_projects"></a> [has\_projects](#input\_has\_projects) | Whether the repository has projects enabled | `bool` | `false` | no |

--- a/branch_protection.tf
+++ b/branch_protection.tf
@@ -1,6 +1,7 @@
 resource "github_branch_protection" "self" {
   allows_deletions                = false
   allows_force_pushes             = false
+  count                           = try(var.has_branch_protection ? 1 : 0, 1)
   enforce_admins                  = true
   pattern                         = "main"
   repository_id                   = github_repository.self.node_id

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "gitignore_template" {
   type        = string
 }
 
+variable "has_branch_protection" {
+  default     = true
+  description = "Whether the repository has branch protection enabled"
+  type        = bool
+}
+
 variable "has_discussions" {
   default     = false
   description = "Whether the repository has discussions enabled"


### PR DESCRIPTION
## Changes

This adds a variable `has_branch_protection` and accompanying logic to allow users to turn off branch protection. This is needed for free users who have private repos since they are not allowed to have branch protection. What ends up happening is that youll have a backlog of branch protections in your terraform runs that just error out