### PR TITLE
Use team ids for permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # terraform-github-repository
 Terraform module which creates GitHub repository resources.
 
-## Impactful Changes
+## Breaking Changes
 
 ### 0.11.0
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ No modules.
 | [github_branch_protection.self](https://registry.terraform.io/providers/integrations/github/6.0.0/docs/resources/branch_protection) | resource |
 | [github_repository.self](https://registry.terraform.io/providers/integrations/github/6.0.0/docs/resources/repository) | resource |
 | [github_team_repository.self](https://registry.terraform.io/providers/integrations/github/6.0.0/docs/resources/team_repository) | resource |
-| [github_team.self](https://registry.terraform.io/providers/integrations/github/6.0.0/docs/data-sources/team) | data source |
 
 ## Inputs
 
@@ -38,6 +37,7 @@ No modules.
 | <a name="input_description"></a> [description](#input\_description) | The description of the repository | `string` | n/a | yes |
 | <a name="input_dismiss_stale_reviews"></a> [dismiss\_stale\_reviews](#input\_dismiss\_stale\_reviews) | Whether to enable dismissing stale pull request reviews | `bool` | `true` | no |
 | <a name="input_enable_pages"></a> [enable\_pages](#input\_enable\_pages) | Whether to enable GitHub Pages | `bool` | `false` | no |
+| <a name="input_enforce_admins"></a> [enforce\_admins](#input\_enforce\_admins) | Whether to enforce branch protection for administrators | `bool` | `false` | no |
 | <a name="input_gitignore_template"></a> [gitignore\_template](#input\_gitignore\_template) | The gitignore template of the repository | `string` | `null` | no |
 | <a name="input_has_branch_protection"></a> [has\_branch\_protection](#input\_has\_branch\_protection) | Whether the repository has branch protection enabled | `bool` | `true` | no |
 | <a name="input_has_discussions"></a> [has\_discussions](#input\_has\_discussions) | Whether the repository has discussions enabled | `bool` | `false` | no |
@@ -54,7 +54,7 @@ No modules.
 | <a name="input_pages_path"></a> [pages\_path](#input\_pages\_path) | The path to the GitHub Pages content | `string` | `null` | no |
 | <a name="input_required_approving_review_count"></a> [required\_approving\_review\_count](#input\_required\_approving\_review\_count) | The number of approving reviews required to change code | `number` | `0` | no |
 | <a name="input_required_status_checks_contexts"></a> [required\_status\_checks\_contexts](#input\_required\_status\_checks\_contexts) | The list of status checks to require in order to merge into this branch | `list(string)` | `[]` | no |
-| <a name="input_teams"></a> [teams](#input\_teams) | The teams to grant access to, and their permission levels | `map(string)` | `{}` | no |
+| <a name="input_teams"></a> [teams](#input\_teams) | The team ids to grant access to, and their permission levels | `map(string)` | `{}` | no |
 | <a name="input_topics"></a> [topics](#input\_topics) | The topics of the repository | `list(string)` | `[]` | no |
 | <a name="input_visibility"></a> [visibility](#input\_visibility) | The visibility of the repository | `string` | `"private"` | no |
 | <a name="input_vulnerability_alerts"></a> [vulnerability\_alerts](#input\_vulnerability\_alerts) | Whether the repository has vulnerability alerts enabled | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # terraform-github-repository
 Terraform module which creates GitHub repository resources.
 
+## Impactful Changes
+
+### 0.11.0
+
+- removes `github_team` data lookup passed from `teams` variable
+- uses team `id` instead of name as key in `teams` variable
+
+#### Example
+
+```hcl
+teams = { "1234567890" = "maintain" }
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/data.tf
+++ b/data.tf
@@ -1,5 +1,0 @@
-data "github_team" "self" {
-  count = length(keys(var.teams))
-
-  slug = keys(var.teams)[count.index]
-}

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "github_team_repository" "self" {
 
   permission = var.teams[keys(var.teams)[count.index]]
   repository = github_repository.self.name
-  team_id    = data.github_team.self[count.index].id
+  team_id    = keys(var.teams)[count.index]
 }
 
 resource "github_repository" "self" {
@@ -43,10 +43,11 @@ resource "github_repository" "self" {
 }
 
 resource "github_branch_protection" "self" {
+  count = try(var.has_branch_protection ? 1 : 0, 1)
+
   allows_deletions                = false
   allows_force_pushes             = false
-  count                           = try(var.has_branch_protection ? 1 : 0, 1)
-  enforce_admins                  = true
+  enforce_admins                  = var.enforce_admins
   pattern                         = "main"
   repository_id                   = github_repository.self.node_id
   require_conversation_resolution = true

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,12 @@ variable "enable_pages" {
   type        = bool
 }
 
+variable "enforce_admins" {
+  default     = false
+  description = "Whether to enforce branch protection for administrators"
+  type        = bool
+}
+
 variable "gitignore_template" {
   default     = null
   description = "The gitignore template of the repository"
@@ -135,7 +141,7 @@ variable "required_status_checks_contexts" {
 
 variable "teams" {
   default     = {}
-  description = "The teams to grant access to, and their permission levels"
+  description = "The team ids to grant access to, and their permission levels"
   type        = map(string)
 
   validation {


### PR DESCRIPTION
## Changes

- uses `team_id` as key in map for `teams` to avoid lookup
