### PR TITLE
feat: add archive on destroy argument

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ resource "github_repository" "self" {
   allow_merge_commit     = var.allow_merge_commit
   allow_rebase_merge     = var.allow_rebase_merge
   allow_squash_merge     = var.allow_squash_merge
+  archive_on_destroy     = var.archive_on_destroy
   auto_init              = true
   delete_branch_on_merge = true
   description            = var.description

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "allow_squash_merge" {
   type        = bool
 }
 
+variable "archive_on_destroy" {
+  default     = true
+  description = "Set to true to archive the repository instead of deleting on destroy"
+  type        = bool
+}
+
 variable "description" {
   description = "The description of the repository"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "allow_squash_merge" {
 }
 
 variable "archive_on_destroy" {
-  default     = true
+  default     = false
   description = "Set to true to archive the repository instead of deleting on destroy"
   type        = bool
 }


### PR DESCRIPTION
The archive_on_destroy setting is currently null because it is not assigned a value by the module. This is acceptable since archive_on_destroy is an optional parameter for the underlying resource.

For reference, see the [Terraform GitHub Provider Documentation](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository#archive_on_destroy).

To avoid accidental repository deletion, it would be beneficial to have an optional input for archive_on_destroy. This was discussed in the Frontend Masters course.
